### PR TITLE
patch for possible SEH/Stack Buffer overflow (CVE-2023-33693)

### DIFF
--- a/Src/C++/EasyPlayerPro/xmlConfig.cpp
+++ b/Src/C++/EasyPlayerPro/xmlConfig.cpp
@@ -40,7 +40,7 @@ int		XMLConfig::LoadConfig(char *filename, PRO_CONFIG_T *pConfig)
 			proConfig.channel[i].autoPlay = 0;
 		}
 
-		SaveConfig(filename, &proConfig);			//²»´æÔÚÅäÖÃÎÄ¼þ, Éú³ÉÒ»¸öÐÂµÄÅäÖÃÎÄ¼þ
+		SaveConfig(filename, &proConfig);			//ä¸å­˜åœ¨é…ç½®æ–‡ä»¶, ç”Ÿæˆä¸€ä¸ªæ–°çš„é…ç½®æ–‡ä»¶
 		if (NULL != pConfig)		memcpy(pConfig, &proConfig, sizeof(PRO_CONFIG_T));
 		return ret;
 	}
@@ -92,7 +92,7 @@ int		XMLConfig::LoadConfig(char *filename, PRO_CONFIG_T *pConfig)
 					TiXmlAttribute *pAttr = pCh->FirstAttribute();
 					while (NULL != pAttr)
 					{
-						if (0 == strcmp(pAttr->Name(), "URL"))				strcpy(proConfig.channel[chIdx].url, pAttr->Value());
+						if (0 == strcmp(pAttr->Name(), "URL"))				strncpy(proConfig.channel[chIdx].url, pAttr->Value(), URL_LENGTH);
 						else if (0 == strcmp(pAttr->Name(), "OSD"))			proConfig.channel[chIdx].showOSD =  atoi(pAttr->Value());
 						else if (0 == strcmp(pAttr->Name(), "Protocol"))	proConfig.channel[chIdx].protocol =  atoi(pAttr->Value());
 						else if (0 == strcmp(pAttr->Name(), "Cache"))		proConfig.channel[chIdx].cache =  atoi(pAttr->Value());
@@ -186,7 +186,7 @@ void	XMLConfig::SaveConfig(char *filename, PRO_CONFIG_T *pConfig)
 		pCh->SetAttribute("ShowToolbar", proConfig.channel[i].showToolbar);
 		pCh->SetAttribute("AutoPlay", proConfig.channel[i].autoPlay);
 	}
-	pRootElm->LinkEndChild(pChannel);                          //Á´½Óµ½½ÚµãRootLv1ÏÂ  
+	pRootElm->LinkEndChild(pChannel);                          //é“¾æŽ¥åˆ°èŠ‚ç‚¹RootLv1ä¸‹  
 
 	xmlDoc.InsertEndChild(*pRootElm) ;
 

--- a/Src/C++/EasyPlayerPro/xmlConfig.h
+++ b/Src/C++/EasyPlayerPro/xmlConfig.h
@@ -2,10 +2,12 @@
 
 #define	XML_CONFIG_FILENAME "EasyPlayerPro.xml"
 
+#define URL_LENGTH 256
+
 
 typedef struct __CHANNEL_INFO_T
 {
-	char		url[256];
+	char		url[URL_LENGTH];
 	int			showOSD;
 	int			protocol;	//1:tcp  other:udp
 	int			cache;
@@ -22,7 +24,7 @@ typedef struct __PRO_CONFIG_T
 	int			fullScreen;
 	int			recordingFileSize;
 	int			recordingDuration;
-	int			recordingFileAutoSegmentation;	//录像文件自动分割
+	int			recordingFileAutoSegmentation;	//脗录脧帽脦脛录镁脳脭露炉路脰赂卯
 
 	CHANNEL_INFO_T	channel[16];
 }PRO_CONFIG_T;


### PR DESCRIPTION
There is a SEH overflow vulnerability caused by using unsafe strcpy() function in xmlconfig.cpp file. A simple fix to this is to replace strcpy() with strncpy() and set a fix length for the URL field at 256.

This ensures that tsingsee/EasyPlayerPro all versions v3.2.19.0106 and v3.6.19.0823 is not vulnerable to a SEH overflow, mainly caused by the usage of unsafe strcpy() function in xmlconfig.cpp file LoadConfig() function, where strcpy() is used to copy over the user controlled URL field in EasyPlayerPro.xml. This leads to a Denial of Service (DoS) exploitation and may lead to arbitrary code execution (RCE) via SEH/stack buffer overflow.

POC:
https://www.youtube.com/watch?v=K27nGHa-hTE&feature=youtu.be&ab_channel=ErnestAng
https://www.youtube.com/watch?v=JkIhyO_z3VU&feature=youtu.be